### PR TITLE
Update shap.py

### DIFF
--- a/omnixai/explainers/tabular/agnostic/shap.py
+++ b/omnixai/explainers/tabular/agnostic/shap.py
@@ -92,8 +92,9 @@ class ShapTabular(TabularExplainer):
         if len(self.ignored_features) == 0:
             explainer = shap.KernelExplainer(
                 self.predict_fn, self.background_data,
-                link="logit" if self.mode == "classification" else "identity", **kwargs
+                link="identity", **kwargs
             )
+		
             shap_values = explainer.shap_values(instances, **kwargs)
 
             for i, instance in enumerate(instances):


### PR DESCRIPTION
Hello, 

I am new to Github and this is my first pull request, so I appreciate any feedback and please let me know if there is any additional information you need. First of all, I would like to thank Salesforce for keeping this wonderful library open-source and free for everyone to use. 

I am the author of a repository 11301858/XAISuite, which streamlines the process of training and explaining models and uses OmniXAI. 

However, using OmniXAI, my program repeatedly threw Value Errors attempting to explain models already trained on sklearn datasets. 

![Screen Shot 2022-11-16 at 4 56 58 PM](https://user-images.githubusercontent.com/66180831/202327818-6baa6545-2788-4a5f-a9ff-17211c2b8732.png)

Note that the model was already trained and that the datasets were preconfigured from sklearn, so the problem was not with the dataset. 

I believed that the source of the error was the following line:

`explanations[name] = self.explainers[name].explain(X=X, **param)`
I was able to use the stack trace to determine the cause of the issue:

![Screen Shot 2022-11-16 at 5 03 09 PM](https://user-images.githubusercontent.com/66180831/202328585-fb74c4d9-bd58-468f-9a92-4b08b1a9e05b.png)

As we can see, the np.log(x/1-x ) term, where x is the probability, is undefined when x is 1 or 0. I did a quick search on this problem and found [this Github issue](https://github.com/slundberg/shap/issues/183), where Scott Lundberg, the inventor of SHAP, suggests a workaround by dropping link = “logit”.

It is OmniXAI that calls SHAP Kernel Explainer with link = "logit", as we can see in a portion of the image above, reproduced below:

![Screen Shot 2022-11-16 at 5 03 54 PM](https://user-images.githubusercontent.com/66180831/202328671-8d80b6ad-c19d-473e-8696-ac67475628b9.png)


OmniXAI purposefully uses link = "logit" for classification and link = "identity" for regression. I am assuming there is a compelling reason that convinced them to do this. Is this because link = "logit" works better for classification than link = "identity"? In any case, OmniXAI did not foresee x being 1 or 0, which is seemingly the case in my program.

After I made a slight modification by changing line 95 in OmniXAI / omnixai / explainers / tabular / agnostic / shap.py to link = "identity", my program now works accurately for all models datasets.

