### PR TITLE
Asking for more flexibility in predict function #1

### DIFF
--- a/omnixai/utils/misc.py
+++ b/omnixai/utils/misc.py
@@ -194,7 +194,7 @@ def build_predict_function(model, preprocess, postprocess, mode):
     # A scikit-learn model
     if isinstance(model, BaseEstimator):
         # A model derived from sklearn.base.BaseEstimator
-        predict_func = model.predict_proba if mode == "classification" else model.predict
+        predict_func = model.predict
     else:
         # A torch model, tensorflow model or general function
         if is_torch_available():


### PR DESCRIPTION
Hello,

Thanks very much for accepting my previous pull request "Update shap.py https://github.com/salesforce/OmniXAI/pull/49" about giving a choice to the user in whether to use link = "identity" or link = "logit".

I have another proposal. On line 197 of misc/utils.py, predict_func is set to model.predict_proba if the model is a classifier and is a BaseEstimator. I believe, that just as with the link, users should be given a choice about whether to use model.predict_proba or model.predict regardless of whether the model is a classifier or a regressor. This is because if predict == False, there is a runtime error for classification models like SVC.

![Screen Shot 2022-12-23 at 1 04 32 PM](https://user-images.githubusercontent.com/66180831/209405374-7114bb8f-00a3-4695-bcd0-1970685154f0.png)


Please let me know if this is a misunderstanding on my part or if there is a good reason why this was not done.

On another note, thank you for guiding me through my first pull request. This is my second one :)

Sincerely,
Shreyan