### PR TITLE
Fixed Get started code snippet in Generate explanation doc

### DIFF
--- a/docs/omnixai.rst
+++ b/docs/omnixai.rst
@@ -207,7 +207,7 @@ these two methods to generate explanations.
 .. code-block:: python
 
    # Generate explanations
-   test_instances = tabular_data[:5]
+   test_instances = test_data[:5]
    local_explanations = explainers.explain(X=test_instances)
    global_explanations = explainers.explain_global(
        params={"pdp": {"features": ["Age", "Education-Num", "Capital Gain",


### PR DESCRIPTION
There is seemingly an error in the "Get started" documentation. While trying to display the dashboard with the provided example, I got an error with a feature shape mismatch.

Upon reading the appropriate documentation for the [omnixai.explainers.tabular](https://opensource.salesforce.com/OmniXAI/latest/omnixai.explainers.tabular.html)  package, I realize one needs to pass the test dataset to `predict(X)`, not the entire dataset.