### PR TITLE
Relax ipython version constraint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         "tqdm",
         "wheel",
         "packaging",
-        "ipython>=8.10.0",
+        "ipython",
         "tabulate",
         "statsmodels>=0.10.1",
         "openai"


### PR DESCRIPTION
Relax ipython dependency constraint as to ease the use of OmniXAI on Google Colab.

Fixes #101.